### PR TITLE
fix build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## ember-cli guides
 
-[![Build Status](https://travis-ci.org/ember-learn/cli-guides.svg?branch=master)](https://travis-ci.org/ember-learn/cli-guides-source)
+[![Build Status](https://travis-ci.org/ember-learn/cli-guides.svg?branch=master)](https://travis-ci.org/ember-learn/cli-guides)
 
 This repository holds the guides and tutorials for the [Ember CLI](https://github.com/ember-cli/ember-cli), a powerful tool that helps you create, develop, and build an Ember app.
 


### PR DESCRIPTION
Travis was showing "unknown" build status, and also not reporting test results correctly.

TIL that if you rename a repo, it makes Travis sad. Solved by "sync"ing from my profile, and then pushing another commit to restart the tests. Then I copied the new badge url from Travis.