### PR TITLE
Write 'Ember Observer' consistently

### DIFF
--- a/guides/basic-use/cli-commands.md
+++ b/guides/basic-use/cli-commands.md
@@ -128,7 +128,7 @@ ember install <addon-name>
 
 ### What it does
 
-`ember install` is used to install addons within your app. An addon is an npm package that was built especially for use in an Ember app. Most addons have a name that starts with `ember`. You can find a full list of addons at [EmberObserver.com](https://emberobserver.com). There are addon versions of many popular npm libraries, as well as packages that are unique to Ember. The majority are open source community addons.
+`ember install` is used to install addons within your app. An addon is an npm package that was built especially for use in an Ember app. Most addons have a name that starts with `ember`. You can find a full list of addons on [Ember Observer](https://emberobserver.com). There are addon versions of many popular npm libraries, as well as packages that are unique to Ember. The majority are open source community addons.
 By convention, most addons have `ember` in the name, but not all of them.
 
 To use non-addon npm packages directly, see [the Ember.js Guide](https://guides.emberjs.com/release/addons-and-dependencies/managing-dependencies/)
@@ -188,7 +188,7 @@ ember build [options]
 
 `ember build` takes all of your app files and turns them into a bundle that is minified and transpiled into browser-ready JavaScript code, styles, and html. The bundled files go into a directory called `dist`. This bundle is what can be deployed to a server. By default, the `build` command uses the `development` environment configuration.
 
-Although you can upload the built files to a server yourself, many Ember projects use a community addon called [ember-cli-deploy](https://github.com/ember-cli-deploy/ember-cli-deploy) to get their apps into production. `ember-cli-deploy` has a plugin system to make it easy to deploy to many cloud vendors. Search [EmberObserver for "deploy"](https://emberobserver.com/?query=deploy) to browse available options.
+Although you can upload the built files to a server yourself, many Ember projects use a community addon called [ember-cli-deploy](https://github.com/ember-cli-deploy/ember-cli-deploy) to get their apps into production. `ember-cli-deploy` has a plugin system to make it easy to deploy to many cloud vendors. Search [Ember Observer for "deploy"](https://emberobserver.com/?query=deploy) to browse available options.
 
 Ember apps can be built with only three environments: development, production, and testing.
 
@@ -203,6 +203,6 @@ ember build --environment production
 ### Learn more
 
 - The [Ember.js Super Rentals Tutorial](https://guides.emberjs.com/release/tutorial/deploying/) has a section on deploying
-- Search community addons for deployment on [EmberObserver](https://emberobserver.com/?query=deploy)
+- Search community addons for deployment on [Ember Observer](https://emberobserver.com/?query=deploy)
 - Enable feature flags in different environments using the
 [environment config](https://guides.emberjs.com/release/configuring-ember/configuring-your-app/)

--- a/guides/index.md
+++ b/guides/index.md
@@ -20,7 +20,7 @@ The CLI comes with a command-line-based help system too. At any point, if you're
 
 There are thousands of JavaScript libraries that work great in Ember. When an [npm package](https://www.npmjs.com/) offers some Ember-specific conveniences, we call it an “addon.” Ember CLI’s addon system provides a way to create reusable units of code, share components and styling, extend the build tooling, and more — all with minimal configuration. 
 
-To view some of the most popular addons, visit [EmberObserver](https://emberobserver.com). 
+To view some of the most popular addons, visit [Ember Observer](https://emberobserver.com).
 
 You can still use your favorite npm packages directly too. If they are not available as addons yet, you can use
 a community tool called [ember-auto-import](https://github.com/ef4/ember-auto-import), include them in the build pipeline yourself, or create a wrapper addon of your own.
@@ -47,4 +47,4 @@ The Ember CLI is developed and maintained by a group of open source contributors
 - [The main ember-cli codebase](https://github.com/ember-cli/ember-cli) 
 - [This documentation site](https://github.com/ember-learn/cli-guides)
 - Official projects under the [ember-cli organization](https://github.com/ember-cli/) 
-- Search the community's CLI plugins on [EmberObserver](https://emberobserver.com)
+- Search the community's CLI plugins on [Ember Observer](https://emberobserver.com)


### PR DESCRIPTION
Previously it was written at different places as "EmberObserver", "Ember Observer", and "EmberObserver.com". This PR makes the usages consistent.

I also change an "at" to "on" because "at EmberObserver.com" seems to make sense for a domain name, but when the ".com" is removed "on Ember Observer" seems to make more sense. And there are other places in the guides where we say "on Ember Observer".

We could standardize on another way of writing the term or even leave in exceptions if there's good reason; this PR would be a good place to discuss. Here are my thoughts:

- "Ember Observer" should be preferred over "EmberObserver" because the former is how emberobserver.com writes the name
- I don't see too much extra benefit of including ".com" in all uses of the name, or even in a single one to introduce it. The name is hyperlinked so users will be able to see upon click the domain name they're taken to.