### PR TITLE
Add section on CONTRIBUTING.md

### DIFF
--- a/guides/writing-addons/documenting.md
+++ b/guides/writing-addons/documenting.md
@@ -8,8 +8,12 @@ This makes the addon easier to search for in the [npm repository](https://www.np
 
 ## The README
 
-Every addon should have a `README.md` file describing why someone might want to use the addon, installation instructions, how to run tests, and contributing guidelines.
+Every addon should have a `README.md` file describing why someone might want to use the addon and how to install it.
 If your addon has a documentation site or demo apps, be sure to include links to them.
+
+## The CONTRIBUTING
+
+ Every new addon contains a `CONTRIBUTING.md` when generated with Ember CLI. This file should describe how to run the addon locally, how to run tests,  and contributing guidelines.
 
 ## Creating a documentation site
 

--- a/guides/writing-addons/documenting.md
+++ b/guides/writing-addons/documenting.md
@@ -13,7 +13,7 @@ If your addon has a documentation site or demo apps, be sure to include links to
 
 ## The CONTRIBUTING
 
- Every new addon contains a `CONTRIBUTING.md` when generated with Ember CLI. This file should describe how to run the addon locally, how to run tests,  and contributing guidelines.
+ Every new addon contains a `CONTRIBUTING.md` when generated with Ember CLI. This file should describe how to run the addon locally, how to run tests, and contributing guidelines.
 
 ## Creating a documentation site
 


### PR DESCRIPTION
I propose adding a section on `CONTRIBUTING.md` since with the merge of https://github.com/ember-cli/ember-cli/pull/8203 a newly generated addon will now contain a `CONTRIBUTING.md` with installation instructions.

Note: This feature is merged but not released yet.