### PR TITLE
Change travis.yml to use Node 8 like the ember.js guides

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "8"
 
 sudo: false
 dist: trusty


### PR DESCRIPTION
As noded in https://github.com/ember-learn/cli-guides/issues/61, we should upgrade to Node 8. This matches what is done in the main guides so I expect it to work here too for our CI.