### PR TITLE
fixing references of Ember CLI and moving to ember-cli

### DIFF
--- a/.local.dic
+++ b/.local.dic
@@ -20,6 +20,8 @@ ember-cli-addon-docs
 ember-concurrency
 ember-d3
 ember-bootstrap
+ember-cli
+ember-cli's
 ember-cli-build
 ember-cli-deploy
 ember-cli-less

--- a/guides/advanced-use/asset-compilation.md
+++ b/guides/advanced-use/asset-compilation.md
@@ -12,19 +12,19 @@ For example, if you place `logo.png` in `public/assets/images`, you can referenc
 templates with `assets/images/logo.png` or in stylesheets with
 `url('/assets/images/logo.png')`.
 
-This functionality of Ember CLI comes from
+This functionality of ember-cli comes from
 [broccoli-asset-rev](https://github.com/rickharrison/broccoli-asset-rev). Be
 sure to check out all the options and usage notes.
 
 ## JS transpiling
 
-Ember CLI automatically transpiles future JavaScript (ES6/ES2015, ES2016 and beyond) into standard ES5
-JavaScript that runs on every browser using [Babel JS](https://babeljs.io) with the [Ember CLI Babel](https://github.com/babel/ember-cli-babel) addon.
+ember-cli automatically transpiles future JavaScript (ES6/ES2015, ES2016 and beyond) into standard ES5
+JavaScript that runs on every browser using [Babel JS](https://babeljs.io) with the [ember-cli Babel](https://github.com/babel/ember-cli-babel) addon.
 
-Internally, Ember CLI Babel uses `babel-preset-env`, which figures out which parts of your code
+Internally, ember-cli Babel uses `babel-preset-env`, which figures out which parts of your code
 need to be transpiled to ES5 by **analyzing your project's browser support targets**. A `target` is a special keyword
 that maps to a [browserlist](https://github.com/ai/browserslist) support rule. These are defined in your
-`config/targets.js` file, which [Ember CLI generates](https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/config/targets.js) like so:
+`config/targets.js` file, which [ember-cli generates](https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/config/targets.js) like so:
 
 
 ```javascript {data-filename=config/targets.js}
@@ -81,11 +81,11 @@ module.exports = function(defaults) {
 };
 ```
 
-As of Version 2.13, Ember CLI uses Babel 6.X for transpilation. Ember CLI versions prior to 2.13 use Babel Babel 5.X, and you can check its documentation for a comprehensive list of [all available transformations](https://github.com/babel/babel.github.io/blob/5.0.0/docs/usage/transformers/index.md) and [options](https://github.com/babel/babel.github.io/blob/5.0.0/docs/usage/options.md).
+As of Version 2.13, ember-cli uses Babel 6.X for transpilation. ember-cli versions prior to 2.13 use Babel Babel 5.X, and you can check its documentation for a comprehensive list of [all available transformations](https://github.com/babel/babel.github.io/blob/5.0.0/docs/usage/transformers/index.md) and [options](https://github.com/babel/babel.github.io/blob/5.0.0/docs/usage/options.md).
 
 ## Source maps
 
-Ember CLI supports producing source maps for your concatenated and minified JS source files.
+ember-cli supports producing source maps for your concatenated and minified JS source files.
 
 Source maps are configured by the EmberApp `sourcemaps` option, and
 are disabled in production by default. Pass `sourcemaps: {enabled: true}` to your EmberApp constructor to enable source maps for JavaScript. Use the `extensions` option to add other formats, such as CSS: `{extensions: ['js', 'css']}`. JS is supported out-of-the-box. CSS is not currently supported. For other source formats, refer to their addons.
@@ -146,7 +146,7 @@ More details on available options to customize JavaScript minification can be fo
 [`ember-cli-uglify` docs](https://github.com/ember-cli/ember-cli-uglify#ember-cli-uglify).
 
 ***Note**: The option object for minifying of JavaScript files was renamed in `ember-cli-uglify@2.x`,
-which is part of Ember CLI's default blueprint since 2.16.0. The option was called `minifyJS`
+which is part of ember-cli's default blueprint since 2.16.0. The option was called `minifyJS`
 for `ember-cli-uglify@1.x`.*
 
 ### Exclude from minification

--- a/guides/advanced-use/blueprints.md
+++ b/guides/advanced-use/blueprints.md
@@ -1,6 +1,6 @@
 Have you ever wanted to define your own custom boilerplate when you create new files in an Ember app? You can do that with blueprints. Blueprints are snippet generators used to create the entities — components, routes, services, models and more — used in your applications. Blueprints allow us to share common Ember patterns in the community. Developers can define blueprints for use in their applications or addons.
 
-Ember's built-in [blueprints](https://github.com/emberjs/ember.js/tree/master/blueprints) are a source of detailed examples to help you learn more about blueprints.  The Ember CLI API docs on [blueprints](https://ember-cli.com/api/classes/Blueprint.html) provide advanced information for developing blueprints.
+Ember's built-in [blueprints](https://github.com/emberjs/ember.js/tree/master/blueprints) are a source of detailed examples to help you learn more about blueprints.  The ember-cli API docs on [blueprints](https://ember-cli.com/api/classes/Blueprint.html) provide advanced information for developing blueprints.
 
 To see a list of all available blueprints with short descriptions of what they do, run `ember generate --help` or `ember help generate`.
 
@@ -42,7 +42,7 @@ installing blueprint
   create blueprints/foo-test/index.js
 ```
 
-Blueprints in your project’s directory take precedence over those packaged with Ember CLI. This makes it easy to override the built-in blueprints by generating one with the same name.
+Blueprints in your project’s directory take precedence over those packaged with ember-cli. This makes it easy to override the built-in blueprints by generating one with the same name.
 
 ### Blueprint Structure
 
@@ -112,7 +112,7 @@ export default function CountDown() {
 }
 ```
 
-Out of the box, Ember CLI provides the following template variables:
+Out of the box, ember-cli provides the following template variables:
 
 - `dasherizedPackageName`
 - `classifiedPackageName`
@@ -227,10 +227,10 @@ The object passed to `locals` looks like this:
 }
 ```
 
-<!-- Old Ember CLI docs or api examples are not correct -->
+<!-- Old ember-cli docs or api examples are not correct -->
 <!-- PR https://github.com/ember-cli/ember-cli/pull/8210 to fix api docs -->
 
-<!-- Options object is extensive and not documented anywhere.  Should be included in Ember CLI API docs -->
+<!-- Options object is extensive and not documented anywhere.  Should be included in ember-cli API docs -->
 
 This hook must return an object or a Promise which resolves to an object. The resolved object will be merged with the before mentioned default `locals`.
 
@@ -301,7 +301,7 @@ The `afterInstall` and `afterUninstall` hooks receive the same arguments as `loc
 
 The `install` hook installs the blueprint and is not normally used when developing blueprints. The hook can be used for advanced blueprints, for example if you don't want your blueprint to install any files.
 
-See the Ember CLI [source](https://github.com/ember-cli/ember-cli/blob/master/lib/models/blueprint.js) for `install` hook details.
+See the ember-cli [source](https://github.com/ember-cli/ember-cli/blob/master/lib/models/blueprint.js) for `install` hook details.
 
 ## Pod blueprints
 

--- a/guides/advanced-use/project-layouts.md
+++ b/guides/advanced-use/project-layouts.md
@@ -1,4 +1,4 @@
-Ember CLI offers two different options for the layout of project files - `classic` and `pods`.
+ember-cli offers two different options for the layout of project files - `classic` and `pods`.
 
 ## Classic layout
 The classic project structure is the default when creating a new Ember app or addon. The classic project structure organizes the filesystem by entity types. 
@@ -20,7 +20,7 @@ app
     └── post.hbs
 ```
 
-The `classic` project provides the easiest way to get started with Ember. It's the easiest way to generate files using Ember CLI.  Addons __should only use__ the `classic` structure for compatibility with either `classic` or `pods-based` consuming applications.
+The `classic` project provides the easiest way to get started with Ember. It's the easiest way to generate files using ember-cli.  Addons __should only use__ the `classic` structure for compatibility with either `classic` or `pods-based` consuming applications.
 
 ## Pods layout
 Pods-based projects organize files by features, combining all entity files into a common directory. The aforementioned example as a `pods-based` project would have this filesystem:

--- a/guides/advanced-use/stylesheets.md
+++ b/guides/advanced-use/stylesheets.md
@@ -1,6 +1,6 @@
 <!-- Needs an intro section and editing -->
 
-Ember CLI supports plain CSS out of the box. You can add your CSS styles to
+ember-cli supports plain CSS out of the box. You can add your CSS styles to
 `app/styles/app.css` and it will be served at `assets/application-name.css`.
 
 <!-- Ought to show how to import stylesheets from node_modules, or link to it in the guides if it's there -->

--- a/guides/api-documentation/index.md
+++ b/guides/api-documentation/index.md
@@ -1,7 +1,7 @@
-The API docs for Ember CLI are mainly for addon authors, advanced Ember app developers, and contributors to the CLI itself.
+The API docs for ember-cli are mainly for addon authors, advanced Ember app developers, and contributors to the CLI itself.
 
 [https://ember-cli.com/api/](https://ember-cli.com/api/) 
 
 The docs are the main resource for information like build pipeline modifications, addon author APIs, advanced configurations, and more.
 
-The API documentation is built from the code comments in the main CLI codebase, [Ember CLI on GitHub](https://github.com/ember-cli/ember-cli). If you spot an issue in the documentation, please open an issue or pull request on that repository.
+The API documentation is built from the code comments in the main CLI codebase, [ember-cli on GitHub](https://github.com/ember-cli/ember-cli). If you spot an issue in the documentation, please open an issue or pull request on that repository.

--- a/guides/appendix/common-issues.md
+++ b/guides/appendix/common-issues.md
@@ -9,8 +9,8 @@ for a collection of various solutions.
 
 ## Installing from behind a proxy
 
-If you're behind a proxy, you might not be able to install because Ember CLI–or
-some of its dependencies–tries to `git clone` a `git://` URL. (In this scenario,
+If you're behind a proxy, you might not be able to install because ember-cli (or
+some of its dependencies) tries to `git clone` a `git://` URL. (In this scenario,
 only `http://` URLs will work).
 
 You'll probably get an error like this:
@@ -45,7 +45,7 @@ See [The Windows Section](/release/appendix/windows/) for more details.
 
 Node.js on Cygwin is no longer supported [more
 details](https://github.com/nodejs/node/wiki/Installation#building-on-cygwin)
-Rather then using Cygwin, we recommend running Ember CLI natively on windows,
+Rather then using Cygwin, we recommend running ember-cli natively on windows,
 or via the new [Windows Subsystem
 Linux](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide).
 
@@ -58,13 +58,13 @@ Linux](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide).
 [Vagrant](https://vagrantup.com) is a system for automatically creating and
 setting up development environments that run in a virtual machine (VM).
 
-Running your Ember CLI development environment from inside of a Vagrant VM will
+Running your ember-cli development environment from inside of a Vagrant VM will
 require some additional configuration and will carry a few caveats.
 
 ### Ports
 
-In order to access your Ember CLI application from your desktop's web browser,
-you'll have to open some forwarded ports into your VM. Ember CLI by default
+In order to access your ember-cli application from your desktop's web browser,
+you'll have to open some forwarded ports into your VM. ember-cli by default
 uses two ports.
 
 * For serving assets the default is `4200`. Can be configured via `--port 4200`.
@@ -91,7 +91,7 @@ from working correctly. There are several workarounds:
 
 ### VM setup
 
-When setting up your VM, install Ember CLI dependencies as you normally would.
+When setting up your VM, install ember-cli dependencies as you normally would.
 Some of these dependencies (such as [broccoli-sass](#sass)) may have native
 dependencies that may require recompilation. To do so run:
 

--- a/guides/appendix/dev-tools.md
+++ b/guides/appendix/dev-tools.md
@@ -1,12 +1,12 @@
 <!-- Copy over code editor content -->
 <!-- This intro paragraph needs improvement -->
 
-This section provides information on integrating Ember into various code editors and how to debug Ember CLI node code.
+This section provides information on integrating Ember into various code editors and how to debug ember-cli node code.
 
 ## Code editor integrations
 
 ### Visual Studio Code
-If you are using [VSCode](https://code.visualstudio.com/) with Ember CLI, there's an [official
+If you are using [VSCode](https://code.visualstudio.com/) with ember-cli, there's an [official
 extension pack](https://marketplace.visualstudio.com/items?itemName=emberjs.emberjs#overview) 
 maintained by the Ember Learning team that adds multiple Ember plugins that can help in 
 Ember development. If you already have VSCode installed on your machine, you can 
@@ -15,19 +15,19 @@ also search for `emberjs.emberjs` inside the [extensions view](https://code.visu
 
 ### Atom
 
-If you are using [Atom](https://atom.io) with Ember CLI, there are some
+If you are using [Atom](https://atom.io) with ember-cli, there are some
 packages available specific to Ember development.
 
 `Atom -> Preferences -> Install`
 
-* [ember-cli-helper](https://atom.io/packages/ember-cli-helper) - Ember CLI integration in Atom
+* [ember-cli-helper](https://atom.io/packages/ember-cli-helper) - ember-cli integration in Atom
 * [ember-tabs](https://atom.io/packages/ember-tabs) - Makes atom.io work better with Ember pods
 * [atom-ember-components](https://atom.io/packages/atom-ember-components) - See all controllers and components that are rendering your component. Currently only works with pods structure.
 * [atom-ember-snippets](https://atom.io/packages/ember-snippets) - Autocomplete for Ember module imports, component, service and route skeletons, and more. 
 
 ### Emacs
 
-If you are using [Emacs](https://www.gnu.org/software/emacs/) with Ember CLI,
+If you are using [Emacs](https://www.gnu.org/software/emacs/) with ember-cli,
 Emacs creates temporary backup, autosave, and lockfiles that interfere with
 broccoli watcher, so they need to either be moved out of the way or disabled.
 To do that, ensure your emacs configuration contains the following:
@@ -65,7 +65,7 @@ to enable it inside those projects.
 
 ### Sublime Text
 
-If you are using [Sublime Text](http://www.sublimetext.com) with Ember CLI,
+If you are using [Sublime Text](http://www.sublimetext.com) with ember-cli,
 by default it will try to index all files in your `tmp` directory for its
 GoToAnything functionality.  This will cause your computer to come to a
 screeching halt @ 90%+ CPU usage, and can significantly increase build times.
@@ -82,7 +82,7 @@ Simply remove these directories from the folders Sublime Text watches:
 
 ### WebStorm
 If you are using [WebStorm](https://www.jetbrains.com/webstorm/) with
-Ember CLI, you will need to modify your `.gitignore` file, enable
+ember-cli, you will need to modify your `.gitignore` file, enable
 `ECMAScript6` settings, and mark certain directories.
 
 First, add the following line to `.gitignore`:
@@ -132,7 +132,7 @@ Search for `Ember.js` and click the Install button.
 
 ### Vim
 
-If you are using [Vim](http://www.vim.org/) with Ember CLI, Vim creates
+If you are using [Vim](http://www.vim.org/) with ember-cli, Vim creates
 temporary backups and autosaves which interfere with broccoli, so they need to
 either be moved out of the way or disabled. To do that, ensure your .vimrc
 contains the following:

--- a/guides/appendix/index.md
+++ b/guides/appendix/index.md
@@ -2,4 +2,4 @@ Apps come in so many types, shapes, and sizes that it's not possible to cover ev
 
 The Appendix is the home of content that may not be frequently used, but is very helpful to developers who are working with stubborn bugs, unusual constraints, or older apps.
 
-Help add to this section by opening issues for the [Ember CLI Guides](https://github.com/ember-learn/cli-guides).
+Help add to this section by opening issues for the [ember-cli Guides](https://github.com/ember-learn/cli-guides).

--- a/guides/appendix/windows.md
+++ b/guides/appendix/windows.md
@@ -1,4 +1,4 @@
-Windows versions as far back as Vista are fully supported when using the Ember CLI.
+Windows versions as far back as Vista are fully supported when using the ember-cli.
 
 To get started ensure the following dependencies are installed:
 
@@ -10,7 +10,7 @@ To get started ensure the following dependencies are installed:
 
 Although supported, Windows performance, at least by default, isn't as good as
 on Linux or MacOS. On a positive note, this story continues to improve. Both
-Microsoft, and the Ember CLI team continue to work on improving these developer
+Microsoft, and the ember-cli team continue to work on improving these developer
 ergonomics.
 
 #### What causes the build slowdown?
@@ -41,7 +41,7 @@ If there was an error, try executing Set-ExecutionPolicy Unrestricted -scope Pro
 
 ### Enabling symlinks
 
-To create symlinks the account running Ember CLI must have the
+To create symlinks the account running ember-cli must have the
 `SeCreateSymbolicLinkPrivilege`. Users in the Administrators group have this
 permission already. However, if UAC (User Access Control) is enabled, users in
 the Administrators group must run their shell using Run As Administrator
@@ -73,6 +73,6 @@ executed for each package and it would immediately start executing them as soon
 as it decided to act on a package resulting in hard-to-debug race conditions.
 
 `npm` 3 is a nearly complete rewrite of `npm`, fixing both issues. Windows users of
-Ember CLI might want to make the switch to `npm` 3 to benefit from its
+ember-cli might want to make the switch to `npm` 3 to benefit from its
 flat module installation (solving most issues involving long path names) as well
 as its multi-stage installer.

--- a/guides/basic-use/assets-and-dependencies.md
+++ b/guides/basic-use/assets-and-dependencies.md
@@ -34,7 +34,7 @@ ember generate <addon-name>
 
 ## npm and Yarn
 
-Ember CLI supports both [npm](https://www.npmjs.com) and [Yarn](https://yarnpkg.com/)
+ember-cli supports both [npm](https://www.npmjs.com) and [Yarn](https://yarnpkg.com/)
 for node modules management.
 
 By default, new apps use `npm`.
@@ -50,7 +50,7 @@ for any `ember install some-addon-name` commands.
 Don't forget to delete the `package-lock.json` file if the app
 already has one.
 In cases where both a `yarn.lock` file and a `package-lock.json`
-file are present, Ember CLI will default to using Yarn.
+file are present, ember-cli will default to using Yarn.
 However, having both files causes confusion for collaborators and
 is incompatible with some CI systems.
 
@@ -73,9 +73,9 @@ app source code and get the `node_modules` installed locally by executing
 
 ### Effects of new dependencies on local servers
 
-When an app is being served locally, the Ember CLI will not watch for changes in the `package.json` file. Therefore,
+When an app is being served locally, the ember-cli will not watch for changes in the `package.json` file. Therefore,
 if you install npm dependencies via `npm install <dependencies>`, you will
-need to restart your Ember CLI server session manually.
+need to restart your ember-cli server session manually.
 
 Dependencies installed with `ember install some-addon-name` will cause a refresh
 of a local server.

--- a/guides/basic-use/cli-commands.md
+++ b/guides/basic-use/cli-commands.md
@@ -149,7 +149,7 @@ ember install ember-cli-sass
 
 ### Learn more
 
-- [Ember CLI Guide](../using-addons/) for using and choosing addons
+- [ember-cli Guide](../using-addons/) for using and choosing addons
 - [The Ember.js Guides](https://guides.emberjs.com/release/addons-and-dependencies/managing-dependencies/) section on Addons and Dependencies
 - [Writing addons](../../writing-addons/) to learn how to make your own addon
 

--- a/guides/basic-use/deploying.md
+++ b/guides/basic-use/deploying.md
@@ -1,10 +1,10 @@
-No matter where you are deploying your app to, the Ember CLI and community ecosystem have tools to help. In this section of the guide, we will go over some general approaches and common configurations.
+No matter where you are deploying your app to, the ember-cli and community ecosystem have tools to help. In this section of the guide, we will go over some general approaches and common configurations.
 
 ## Behind the scenes of deploying
 
-No matter which framework you use, there are some processing steps that the code probably has to go through before it is ready to be shared on the internet. For some frameworks, you need to learn all these steps and choose your own toolset. However, thanks to the hard work of many contributors across the years, the Ember CLI and community tools already have these steps set up.
+No matter which framework you use, there are some processing steps that the code probably has to go through before it is ready to be shared on the internet. For some frameworks, you need to learn all these steps and choose your own toolset. However, thanks to the hard work of many contributors across the years, the ember-cli and community tools already have these steps set up.
 
-As a result, you may not need to understand or configure build steps, but it's still helpful to have some background knowledge and terminology. Here are some common steps that the Ember CLI handles for you:
+As a result, you may not need to understand or configure build steps, but it's still helpful to have some background knowledge and terminology. Here are some common steps that the ember-cli handles for you:
 
 - Compilation: Instead of having dozens of files, many are combined together into a smaller number.
 - Minification and uglification: code is optimized for speedy evaluation by the browser, as opposed to human readability.
@@ -31,9 +31,9 @@ The results of the `build` command are placed in the `dist` directory within you
 
 For a tutorial that shows how to build your app and upload it to a web host using `scp` and `rsync`, see the [Official Ember.js Tutorial](https://guides.emberjs.com/release/tutorial/deploying/).
 
-### Ember CLI Deploy
+### ember-cli Deploy
 
-[ember-cli-deploy](http://ember-cli-deploy.com/) is a very popular community-built addon for the Ember CLI. What this means is that it's not built into the CLI by default, but it adds commands and configurations that should feel familiar to an Ember developer. The main benefit is that you set it up once and may never have to think about it again.
+[ember-cli-deploy](http://ember-cli-deploy.com/) is a very popular community-built addon for the ember-cli. What this means is that it's not built into the CLI by default, but it adds commands and configurations that should feel familiar to an Ember developer. The main benefit is that you set it up once and may never have to think about it again.
 
 `ember-cli-deploy` provides the `ember deploy` command, some build hooks, and configuration files to your project. There are many [`ember-cli-deploy` plugins](https://www.emberobserver.com/categories/ember-cli-deploy-plugins) that help you deploy to many different destinations and web hosting services, such as AWS S3 or GitHub pages.
 

--- a/guides/basic-use/index.md
+++ b/guides/basic-use/index.md
@@ -1,4 +1,4 @@
-Learn how to install the Ember CLI on Linux, Mac, and Windows.
+Learn how to install the ember-cli on Linux, Mac, and Windows.
 
 ## Prerequisites
 
@@ -15,7 +15,7 @@ We'll know installation is successful when `npm --version` or `yarn --version` r
 It is recommended to install the most recent LTS (long-term support) version of `node`.
 Restart the console after installing your package manager.
 
-## Installing the Ember CLI
+## Installing the ember-cli
 
 ```shell
 npm install -g ember-cli

--- a/guides/basic-use/upgrading.md
+++ b/guides/basic-use/upgrading.md
@@ -6,7 +6,7 @@ There are three kinds of upgrades for normal Ember app development:
 
 ## Upgrading the CLI version
 
-The Ember CLI is backwards-compatible, meaning that the latest CLI can be used with older app versions. New versions of the CLI are released roughly every 6 weeks, in step with versions of Ember.js itself.
+The ember-cli is backwards-compatible, meaning that the latest CLI can be used with older app versions. New versions of the CLI are released roughly every 6 weeks, in step with versions of Ember.js itself.
 
 Upgrade instructions are published with [each release](https://github.com/ember-cli/ember-cli/releases).
 
@@ -45,13 +45,13 @@ If you installed `ember-cli-update` globally, run the following command inside y
 ember-cli-update
 ```
 
-or if you installed as an Ember CLI command, run
+or if you installed as an ember-cli command, run
 
 ```shell
 ember update
 ```
 
-This will update your app or addon to the latest Ember CLI version. It does this by fetching the latest version and comparing it to your project's Ember CLI version. It then applies a diff of the changes from the latest version to your project. It will only modify the files if there are changes between your project's version and the latest version, and it will only change the section necessary, not the entire file.
+This will update your app or addon to the latest ember-cli version. It does this by fetching the latest version and comparing it to your project's ember-cli version. It then applies a diff of the changes from the latest version to your project. It will only modify the files if there are changes between your project's version and the latest version, and it will only change the section necessary, not the entire file.
 
 You will probably encounter merge conflicts, in which the default behavior is to let you resolve conflicts on your own. You can supply the `--resolve-conflicts` option to run your system's git merge tool if any conflicts are found.
 
@@ -96,7 +96,7 @@ git reset --hard
 git clean -f
 ```
 
-If it is helpful to see a side-by-side comparison between your app and a brand-new app, you can visit the [Ember CLI releases](https://github.com/ember-cli/ember-cli/releases), choose the correct version, and look inside the `blueprints` directory.
+If it is helpful to see a side-by-side comparison between your app and a brand-new app, you can visit the [ember-cli releases](https://github.com/ember-cli/ember-cli/releases), choose the correct version, and look inside the `blueprints` directory.
 
 ### Managing major upgrades
 

--- a/guides/index.md
+++ b/guides/index.md
@@ -1,11 +1,11 @@
-The Ember CLI (command line interface) is the official way to create, build, test, and serve the files that make up an Ember.js app or addon.
-Many things have to happen before any web app is ready for the browser, and the Ember CLI helps you get there with zero configuration.
+The ember-cli (command line interface) is the official way to create, build, test, and serve the files that make up an Ember.js app or addon.
+Many things have to happen before any web app is ready for the browser, and the ember-cli helps you get there with zero configuration.
 
 ```shell
 npm install -g ember-cli
 ```
 
-Visit [Ember CLI](https://github.com/ember-cli/ember-cli) on GitHub 
+Visit [ember-cli](https://github.com/ember-cli/ember-cli) on GitHub 
 and the [Ember.js Release Blog Posts](https://www.emberjs.com/blog/tags/releases.html)
 for information on the latest releases and new features.
 
@@ -18,7 +18,7 @@ The CLI comes with a command-line-based help system too. At any point, if you're
 
 ## What are addons?
 
-There are thousands of JavaScript libraries that work great in Ember. When an [npm package](https://www.npmjs.com/) offers some Ember-specific conveniences, we call it an “addon.” Ember CLI’s addon system provides a way to create reusable units of code, share components and styling, extend the build tooling, and more — all with minimal configuration.
+There are thousands of JavaScript libraries that work great in Ember. When an [npm package](https://www.npmjs.com/) offers some Ember-specific conveniences, we call it an “addon.” ember-cli’s addon system provides a way to create reusable units of code, share components and styling, extend the build tooling, and more — all with minimal configuration.
 
 To view some of the most popular addons, visit [Ember Observer](https://emberobserver.com). 
 
@@ -27,7 +27,7 @@ a community tool called [ember-auto-import](https://github.com/ef4/ember-auto-im
 
 ## Why do we need a CLI?
 
-The Ember CLI is like a dependency packager, test runner, optimizer, and local server all rolled into one. Since all the features were built to work together, common tasks (such as upgrading the app version or deploying) can be automated with production-ready, open source plugins. The CLI is backwards-compatible with older Ember apps and maintains a six-week release schedule.
+The ember-cli is like a dependency packager, test runner, optimizer, and local server all rolled into one. Since all the features were built to work together, common tasks (such as upgrading the app version or deploying) can be automated with production-ready, open source plugins. The CLI is backwards-compatible with older Ember apps and maintains a six-week release schedule.
 
 The CLI's job is to make your work easier.
 It was built with the philosophy that a developer should be able to focus on building great apps, not re-engineering how to fit all the pieces together at each stage of an app's lifecycle. The result is that apps are more maintainable and approachable, since there are established architectural patterns across individuals, teams, and companies.
@@ -40,11 +40,11 @@ Do you have questions? Run into an issue or a bug? Get support from the communit
 
 ## Contributing
 
-The Ember CLI is developed and maintained by a group of open source contributors from many different companies and backgrounds. If you have an idea for a feature, a bug to report, or just want to help out where it is needed, you can reach the team via [GitHub](https://github.com/ember-cli), the [Ember Community forums and chat](https://www.emberjs.com/community/), or drop by the weekly meeting that is open to the public.
+The ember-cli is developed and maintained by a group of open source contributors from many different companies and backgrounds. If you have an idea for a feature, a bug to report, or just want to help out where it is needed, you can reach the team via [GitHub](https://github.com/ember-cli), the [Ember Community forums and chat](https://www.emberjs.com/community/), or drop by the weekly meeting that is open to the public.
 
 ### Places to contribute
 
-- [The main Ember CLI codebase](https://github.com/ember-cli/ember-cli) 
+- [The main ember-cli codebase](https://github.com/ember-cli/ember-cli) 
 - [This documentation site](https://github.com/ember-learn/cli-guides)
-- Official projects under the [Ember CLI organization](https://github.com/ember-cli/) 
+- Official projects under the [ember-cli organization](https://github.com/ember-cli/) 
 - Search the community's CLI plugins on [Ember Observer](https://emberobserver.com)

--- a/guides/pages.yml
+++ b/guides/pages.yml
@@ -1,7 +1,7 @@
 - title: 'Introduction'
   url: 'index'
   pages:
-    - title: "The Ember CLI"
+    - title: "The ember-cli"
       url: ""
 
 - title: 'Basic use'

--- a/guides/writing-addons/documenting.md
+++ b/guides/writing-addons/documenting.md
@@ -13,7 +13,7 @@ If your addon has a documentation site or demo apps, be sure to include links to
 
 ## The CONTRIBUTING
 
- Every new addon contains a `CONTRIBUTING.md` when generated with Ember CLI. This file should describe how to run the addon locally, how to run tests, and contributing guidelines.
+ Every new addon contains a `CONTRIBUTING.md` when generated with ember-cli. This file should describe how to run the addon locally, how to run tests, and contributing guidelines.
 
 ## Creating a documentation site
 
@@ -31,7 +31,7 @@ For more inspiration, take a look at how your favorite addons do their documenta
 
 [Ember Observer](https://www.emberobserver.com/) is an independent, community-made resource that rates and lists addons.
 
-When you create an addon using the Ember CLI, it includes tags in the `package.json` that help it get picked up for inclusion in Ember Observer. There are objective and subjective evaluations that factor into an addon's overall score and ranking. Read more about the scoring [here](https://www.emberobserver.com/about).
+When you create an addon using the ember-cli, it includes tags in the `package.json` that help it get picked up for inclusion in Ember Observer. There are objective and subjective evaluations that factor into an addon's overall score and ranking. Read more about the scoring [here](https://www.emberobserver.com/about).
 
 ## Following SemVer
 

--- a/guides/writing-addons/index.md
+++ b/guides/writing-addons/index.md
@@ -8,7 +8,7 @@ Although an addon looks and feels a lot like an Ember app, it is important to wo
 
 ### Generating the addon files
 
-Use the Ember CLI to create the file structure for the addon. Run this command in a fresh directory, not inside an existing Ember app:
+Use the ember-cli to create the file structure for the addon. Run this command in a fresh directory, not inside an existing Ember app:
 
 ```shell
 ember addon <addon-name> [options]

--- a/guides/writing-addons/intro-tutorial.md
+++ b/guides/writing-addons/intro-tutorial.md
@@ -101,7 +101,7 @@ Whatever goes inside the block form addon will show up where the `{{yield}}` was
 
 ### Styling a UI component addon
 
-Addon developers have many options for handling styles within their addons. For example, we could stick to plain old CSS, or use a preprocessor like Less or Sass. Most addon authors prefer Sass. We could automatically style the UI elements when they are used in an app, or we could let the developer who installed the addon choose which stylesheets to include. Here are a few different approaches. Luckily, the Ember CLI handles most of the work for us and we don't have to worry about the inner workings of asset compilation.
+Addon developers have many options for handling styles within their addons. For example, we could stick to plain old CSS, or use a preprocessor like Less or Sass. Most addon authors prefer Sass. We could automatically style the UI elements when they are used in an app, or we could let the developer who installed the addon choose which stylesheets to include. Here are a few different approaches. Luckily, the ember-cli handles most of the work for us and we don't have to worry about the inner workings of asset compilation.
 
 #### Automatically including CSS stylesheets in addons
 
@@ -151,7 +151,7 @@ If there are any problems getting this to work, one strategy is to build the add
 
 #### Using CSS preprocessors for the addon's stylesheets
 
-While this guide focuses on the "out of the box" behavior of addons and the Ember CLI, there are some well-established patterns for handling stylesheets in a way that is scalable and maintainable. A CSS preprocessor like Sass allows you to nest style rules, use variables, and do simple mathematical operations.
+While this guide focuses on the "out of the box" behavior of addons and the ember-cli, there are some well-established patterns for handling stylesheets in a way that is scalable and maintainable. A CSS preprocessor like Sass allows you to nest style rules, use variables, and do simple mathematical operations.
 
 The best way to learn how to use CSS preprocessors in your addon is to consult the documentation for the preprocessor addon of your choice, and study how other addon authors have implemented stylesheets. For example, [ember-styleguide](https://github.com/ember-learn/ember-styleguide/) is a UI component library that was made for the main Ember websites. It uses [ember-cli-sass](https://www.emberobserver.com/addons/ember-cli-sass) to manage styles. You can search [Ember Observer](https://emberobserver.com) for many more examples of styling in action!
 
@@ -173,7 +173,7 @@ For more information about building interactivity for your addon, reference the 
 
 ## Writing a JavaScript utilities addon
 
-Many addons have no UI components in them, or they offer a combination of JavaScript utilities and template helpers. In the regular npm ecosystem, JavaScript utility libraries are some of the most common packages. Although we could write a normal node package, providing an Ember addon to developers has some advantages. The developers don't need to worry about how to import a normal npm package. They can use `ember install our-addon-name` and get going right away. An addon can also take advantage of Ember or Ember CLI-specific APIs.
+Many addons have no UI components in them, or they offer a combination of JavaScript utilities and template helpers. In the regular npm ecosystem, JavaScript utility libraries are some of the most common packages. Although we could write a normal node package, providing an Ember addon to developers has some advantages. The developers don't need to worry about how to import a normal npm package. They can use `ember install our-addon-name` and get going right away. An addon can also take advantage of Ember or ember-cli specific APIs.
 
 ### Providing public API methods in the addon
 
@@ -290,10 +290,10 @@ Addons are configured using the `ember-addon` hash in the `package.json` file.
 By default, the `configPath` property is defined to point to the config directory of the test dummy application.  All other properties are optional.
 
 ### before and after
-These properties specify whether your ember-addon must run "before" or "after" any other Ember CLI addons. Both of these properties can take either a string or an array of strings. The string is the name of another Ember CLI addon, as defined in the `package.json` of the other addon.
+These properties specify whether your ember-addon must run "before" or "after" any other ember-cli addons. Both of these properties can take either a string or an array of strings. The string is the name of another ember-cli addon, as defined in the `package.json` of the other addon.
 
 ### defaultBlueprint
-Addons have a default blueprint that will automatically run when the addon is installed.  By convention, Ember will run the blueprint named after the `name` property in `package.json` 
+Addons have a default blueprint that will automatically run when the addon is installed.  By convention, Ember will run the blueprint named after the `name` property in `package.json`
 
 You may specify a different name using `defaultBlueprint`. See the [addon blueprints](../../advanced-use/blueprints/#addonblueprints) for more information on the default blueprint.
 


### PR DESCRIPTION
This is related to https://github.com/ember-learn/guides-source/issues/184

Essentially the gist of this PR is that the project is actually called `ember-cli` not `Ember CLI` so we should make sure that we refer to it correctly in all places 👍 