### PR TITLE
Fix typo in filename reference and fix incoherence in examples

### DIFF
--- a/guides/writing-addons/intro-tutorial.md
+++ b/guides/writing-addons/intro-tutorial.md
@@ -133,7 +133,7 @@ We can do this by creating stylesheets in the `app/styles/` directory instead. T
 
 Let's create `app/styles/my-addon-name.css` and add a rule to it:
 
-```css {data-filename=aoo/styles/my-addon-name.css}
+```css {data-filename=app/styles/my-addon-name.css}
 .addon-name-button {
   border: black solid 2px;
 }
@@ -142,7 +142,7 @@ Let's create `app/styles/my-addon-name.css` and add a rule to it:
 For the stylesheet to be active in the app the addon is used in, the developer for that app must explicitly `import` the stylesheet by name. This must be done at the very top of the app's `app.css` file.
 
 ```css {data-filename=app/styles/app.css}
-@import 'our-addon-name.css'
+@import 'my-addon-name.css'
 ```
 
 Then, restart your local server to see the changes in action.


### PR DESCRIPTION
The example's CSS file was named `app/styles/my-addon-name.css` but the import example was `@import 'our-addon-name.css'`, making the example hard to understand.

There was also a typo in a sample path

This PR originates from the discussion in #95, and fixes typos made in #101 