### PR TITLE
Update intro-tutorial.md

### DIFF
--- a/guides/writing-addons/intro-tutorial.md
+++ b/guides/writing-addons/intro-tutorial.md
@@ -68,6 +68,7 @@ We should now see our addon in action!
 - `404 not found` means we forgot to `yarn` or `npm install`
 - Make sure all the files have been saved.
 - Did you rename or relocate any files after they were created? This is prone to mistakes, and the resulting errors can be really strange. It is best to create files using the CLI.
+- If your npm searches for the package in npm registry, provide the file-path instead of "*" in package.json of your ember application; E.g: `"addon-name": "file:relative/or/absolute/addon-path"`
 
 ### Making a UI component available in block form
 

--- a/guides/writing-addons/intro-tutorial.md
+++ b/guides/writing-addons/intro-tutorial.md
@@ -68,7 +68,8 @@ We should now see our addon in action!
 - `404 not found` means we forgot to `yarn` or `npm install`
 - Make sure all the files have been saved.
 - Did you rename or relocate any files after they were created? This is prone to mistakes, and the resulting errors can be really strange. It is best to create files using the CLI.
-- If your npm searches for the package in npm registry, provide the file-path instead of "*" in package.json of your ember application; E.g: `"addon-name": "file:relative/or/absolute/addon-path"`
+- If your npm searches for the package in npm registry, provide the file-path instead of "*" in package.json of your ember application: 
+```"addon-name": "file:relative/or/absolute/addon-path"```
 
 ### Making a UI component available in block form
 


### PR DESCRIPTION
This problem occurs when we give `npm install` after linking the addon in ember application. The npm by default checks the npm registry for our addon, overriding the addon in local. This result in 404 error of package not found in npm registry.