### PR TITLE
Update intro-tutorial.md

### DIFF
--- a/guides/writing-addons/intro-tutorial.md
+++ b/guides/writing-addons/intro-tutorial.md
@@ -56,7 +56,7 @@ There are several options to see the addon in action. We could use `npm link` or
 **From the directory of the app using the addon:**
 1. `yarn link <addon-name>` or `npm link <addon-name>`.
 2. In the Ember app's `package.json`, add a `devDependencies` entry for your addon, like `"addon-name": "*"`. The `*` means that it will include all version numbers of our addon.
-3. Run `yarn install` or `npm install` in the app (for first time, `npm install --offline` must be used instead as `npm install`, by default, will check on npm registry before looking in your local storage)
+3. Run `yarn install` or `npm install` in the app (for first time use `npm install --prefer-offline` or else `npm install --offline` instead of `npm install`. This is because `npm install` by default, will check online npm registry for your addon instead of your local storage)
 4. Add a reference to your addon's component somewhere in an app template, like `<ComponentName @buttonLabel="Register" />`
 5. Run a local server with `ember serve` and visit [http://localhost:4200](http://localhost:4200)
 

--- a/guides/writing-addons/intro-tutorial.md
+++ b/guides/writing-addons/intro-tutorial.md
@@ -56,7 +56,7 @@ There are several options to see the addon in action. We could use `npm link` or
 **From the directory of the app using the addon:**
 1. `yarn link <addon-name>` or `npm link <addon-name>`.
 2. In the Ember app's `package.json`, add a `devDependencies` entry for your addon, like `"addon-name": "*"`. The `*` means that it will include all version numbers of our addon.
-3. Run `yarn install` or `npm install` in the app
+3. Run `yarn install` or `npm install` in the app (for first time, `npm install --offline` must be used instead as `npm install`, by default, will check on npm registry before looking in your local storage)
 4. Add a reference to your addon's component somewhere in an app template, like `<ComponentName @buttonLabel="Register" />`
 5. Run a local server with `ember serve` and visit [http://localhost:4200](http://localhost:4200)
 


### PR DESCRIPTION
When we do `npm install` npm checks for our addon in npm registry by default. But we haven't published it to npm registry yet.
So we need to use `npm install --prefer-offline` or `npm install --offline` so we override npm's default behaviour and make it install all packages from cache or local storage.