### PR TITLE
Add section on .ember-cli configuration

### DIFF
--- a/.local.dic
+++ b/.local.dic
@@ -69,6 +69,7 @@ production-env
 Quickstart
 rerender
 retext-spell
+runtime
 S3
 scalable
 *semver

--- a/guides/appendix/configuration.md
+++ b/guides/appendix/configuration.md
@@ -1,0 +1,27 @@
+Ember CLI’s runtime is configurable via a file named `.ember-cli`. The JSON-formatted file is in project's root directory and can include any command-line options for `ember generate`, `ember serve` or `ember test`. 
+
+Command line options are passed in a dasherized form on the command line but they must be in camel cased in `.ember-cli`. For example
+
+```shell
+ember serve --live-reload false
+```
+
+would be `liveReload` in the configuration file.
+
+```json {data-filename=.ember-cli}
+{
+  "liveReload": false
+}
+```
+Every development environment will be different but a realistic example setting `--port` and `--proxy` is shown below:
+
+```json {data-filename=.ember-cli}
+{
+  // disableAnalytics added by ember new
+  "disableAnalytics": false, 
+  "port" : 8080,
+  "proxy": "http://localhost:3000"
+}
+```
+
+For a complete list of command line options run `ember help`.

--- a/guides/pages.yml
+++ b/guides/pages.yml
@@ -59,6 +59,8 @@
   pages:
   - title: 'Overview'
     url: 'index'
+  - title: 'Configuration'
+    url: 'configuration'
   - title: 'Windows support'
     url: 'windows'
   - title: 'Developer tools'


### PR DESCRIPTION
Info on `.ember-cli` configuration wasn't copied over from old cli guides.  After publishing, I'll do another PR to link back here were it's mentioned in the [Ember guides](https://guides.emberjs.com/release/configuring-ember/configuring-ember-cli/)