### PR TITLE
Update dev-tools.md with more vim details

### DIFF
--- a/guides/appendix/dev-tools.md
+++ b/guides/appendix/dev-tools.md
@@ -136,10 +136,10 @@ If you are using [Vim](http://www.vim.org/) with Ember CLI, Vim creates
 temporary backups and autosaves which interfere with broccoli, so they need to
 either be moved out of the way or disabled.
 
-#### Change Temporary Backup and Autosave Locations
+#### Change temporary backup and autosave locations
 
 By default, Vim places the temporary backup and autosave files right next to
-the associated file.  If you change where Vim puts these backup and autosave files,
+the associated file. If you change where Vim puts these backup and autosave files,
 you can still get the benefits of these features without it interferring with Ember.js
 or your build.
 
@@ -155,7 +155,7 @@ And make sure to create the directories:
 mkdir -p ~/.vim/backup; mkdir -p ~/.vim/swap; mkdir -p ~/.vim/undo
 ```
 
-#### Disable Temporary Backups and Autosave Locations
+#### Disable temporary backups and autosave locations
 
 If you'd like to disable backups, you could add to your .vimrc:
 ```shell

--- a/guides/appendix/dev-tools.md
+++ b/guides/appendix/dev-tools.md
@@ -134,9 +134,16 @@ Search for `Ember.js` and click the Install button.
 
 If you are using [Vim](http://www.vim.org/) with Ember CLI, Vim creates
 temporary backups and autosaves which interfere with broccoli, so they need to
-either be moved out of the way or disabled. To do that, ensure your .vimrc
-contains the following:
+either be moved out of the way or disabled.
 
+#### Change Temporary Backup and Autosave Locations
+
+By default, Vim places the temporary backup and autosave files right next to
+the associated file.  If you change where Vim puts these backup and autosave files,
+you can still get the benefits of these features without it interferring with Ember.js
+or your build.
+
+In your .vimrc, add:
 ```shell
 set backupdir=~/.vim/backup//
 set directory=~/.vim/swap//
@@ -147,6 +154,17 @@ And make sure to create the directories:
 ```shell
 mkdir -p ~/.vim/backup; mkdir -p ~/.vim/swap; mkdir -p ~/.vim/undo
 ```
+
+#### Disable Temporary Backups and Autosave Locations
+
+If you'd like to disable backups, you could add to your .vimrc:
+```shell
+set nobackup
+set noswap
+set noundofile
+```
+
+#### Plugins
 
 Some useful Vim plugins for working with Ember.js:
 


### PR DESCRIPTION
The vim section said you could either move backups or disable them but didn't give information on how to disable them.

This adds instructions on how to do that and reformats that section a bit.