### PR TITLE
Fix internal page link

### DIFF
--- a/guides/basic-use/upgrading.md
+++ b/guides/basic-use/upgrading.md
@@ -28,7 +28,7 @@ Upgrade experience depends on whether the app should have a major, minor, or pat
 
 1. Moving from patch versions (like 3.4.1 to 3.4.2) will not change the app's behavior. They are mostly bugfixes and internal refactors. These upgrades are usually very quick and require no changes besides changing some dependency versions in `package.json`.
 2. Upgrading minor versions (like 3.4 to 3.5) will give access to new features, but the codebase will not need to change, so these are also usually very quick. Afterwards, developers may see new notices about deprecations, whether from their own app or addons they are using. Deprecations are warnings that some API or behavior will be changed in the future for a major release (like Ember 2 to 3).
-2. Major version upgrades (like Ember 2 to 3) introduce breaking changes. Before the upgrade can be made, code inside the app may need to change. See [Managing major upgrades](#managing-major-upgrades) below for the overall strategy.
+2. Major version upgrades (like Ember 2 to 3) introduce breaking changes. Before the upgrade can be made, code inside the app may need to change. See [Managing major upgrades](#managingmajorupgrades) below for the overall strategy.
 
 Developers who find it challenging to upgrade minor versions as frequently as Ember does are encouraged to choose LTS or "long-term support" versions of Ember, which receive security updates for an extended time after release.
 See the [Ember release blog posts](https://www.emberjs.com/blog/tags/releases.html) to find the latest LTS version.


### PR DESCRIPTION
Incorrect id in `Managing major upgrades` link, updates so link works as expected.