### PR TITLE
Mk/public

### DIFF
--- a/guides/writing-addons/index.md
+++ b/guides/writing-addons/index.md
@@ -38,7 +38,7 @@ Fortunately, when we run `ember generate component my-component-name` in an addo
 You can add static assets in the `public/` directory in your addon, and they will automatically be
 merged into the public directory in the host app under a folder with the name of your addon.
 
-For example, if your addon is published to NPM as `@foo/my-awesome-addon`, and it contains an
+For example, if your addon is published to npm as `@foo/my-awesome-addon`, and it contains an
 image at `public/icon.png`, the host app can reference it as
 `/@foo/my-awesome-addon/icon.png` in CSS or JS.
 

--- a/guides/writing-addons/index.md
+++ b/guides/writing-addons/index.md
@@ -40,7 +40,7 @@ merged into the public directory in the host app under `/your-addon-name/`.
 For example, if you add an image at `public/icon.png`, the host app can reference it as
 `/your-addon-name/icon.png` in CSS or JS.
 
-Note that if your addon is published into an npm restricted scope, the final asset path also
+If your addon is published into an npm restricted scope, the final asset path also
 includes that. For example, if your addon is called `@foo/my-awesome-addon`, the same image file
 described above will be available at `/@foo/my-awesome-addon/icon.png`.
 

--- a/guides/writing-addons/index.md
+++ b/guides/writing-addons/index.md
@@ -33,6 +33,17 @@ The default way to make a component is to put the implementation in `addon/`, wh
 
 Fortunately, when we run `ember generate component my-component-name` in an addon project, the CLI takes care of all this re-exporting business. It creates the necessary files and code for us. Addon authors don't usually need to think about the `app` directory or do any work in it.
 
+#### `public/`
+
+You can add static assets in the `public/` directory in your addon, and they will automatically be
+merged into the public directory in the host app under `/your-addon-name/`.
+For example, if you add an image at `public/icon.png`, the host app can reference it as
+`/your-addon-name/icon.png` in CSS or JS.
+
+Note that if your addon is published into an npm restricted scope, the final asset path also
+includes that. For example, if your addon is called `@foo/my-awesome-addon`, the same image file
+described above will be available at `/@foo/my-awesome-addon/icon.png`.
+
 #### `index.js`
 
 An addon will leverage npm conventions and look for an `index.js` as the entry point, unless another entry point is specified via the "main" property in the `package.json` file. You are encouraged to use `index.js` as the addon entry point for your addon. `index.js` is also where you add hooks if you're doing something intermediate or advanced with your addon.

--- a/guides/writing-addons/index.md
+++ b/guides/writing-addons/index.md
@@ -36,13 +36,11 @@ Fortunately, when we run `ember generate component my-component-name` in an addo
 #### `public/`
 
 You can add static assets in the `public/` directory in your addon, and they will automatically be
-merged into the public directory in the host app under `/your-addon-name/`.
-For example, if you add an image at `public/icon.png`, the host app can reference it as
-`/your-addon-name/icon.png` in CSS or JS.
+merged into the public directory in the host app under a folder with the name of your addon.
 
-If your addon is published into an npm restricted scope, the final asset path also
-includes that. For example, if your addon is called `@foo/my-awesome-addon`, the same image file
-described above will be available at `/@foo/my-awesome-addon/icon.png`.
+For example, if your addon is published to NPM as `@foo/my-awesome-addon`, and it contains an
+image at `public/icon.png`, the host app can reference it as
+`/@foo/my-awesome-addon/icon.png` in CSS or JS.
 
 #### `index.js`
 


### PR DESCRIPTION
I went looking for docs on the `public/` folder. Turns out they are on the old site here: https://ember-cli.com/extending/#addon-project-structure, but not here. 

~~Got a little carried away with editing and made some other changes in another commit too. Happy to do a couple round of edits if needed, but if they're too controversial, I can just remove the commit also :) (Or someone can merge and update them to better language also!)~~