### PR TITLE
Update reference about importing npm packages

### DIFF
--- a/guides/index.md
+++ b/guides/index.md
@@ -5,7 +5,7 @@ Many things have to happen before any web app is ready for the browser, and the 
 npm install -g ember-cli
 ```
 
-Visit [Ember CLI](https://github.com/ember-cli/ember-cli) on GitHub 
+Visit [Ember CLI](https://github.com/ember-cli/ember-cli) on GitHub
 and the [Ember.js Release Blog Posts](https://www.emberjs.com/blog/tags/releases.html)
 for information on the latest releases and new features.
 
@@ -20,10 +20,11 @@ The CLI comes with a command-line-based help system too. At any point, if you're
 
 There are thousands of JavaScript libraries that work great in Ember. When an [npm package](https://www.npmjs.com/) offers some Ember-specific conveniences, we call it an “addon.” Ember CLI’s addon system provides a way to create reusable units of code, share components and styling, extend the build tooling, and more — all with minimal configuration.
 
-To view some of the most popular addons, visit [Ember Observer](https://emberobserver.com). 
+To view some of the most popular addons, visit [Ember Observer](https://emberobserver.com).
 
-You can still use your favorite npm packages directly too. If they are not available as addons yet, you can use
-a community tool called [ember-auto-import](https://github.com/ef4/ember-auto-import), include them in the build pipeline yourself, or create a wrapper addon of your own.
+Although Ember-specific packages are more specific, you can use your favorite npm packages directly too.
+By default, Ember apps created through Ember CLI include the `ember-auto-import` dependency, which enables importing npm packages directly. For example, if you want to use the Highcharts library in your application,
+you can install and import it in your application without any other configuration. Be sure to visit the [ember-auto-import](https://github.com/ef4/ember-auto-import) documentation for more advanced usage!
 
 ## Why do we need a CLI?
 
@@ -44,7 +45,7 @@ The Ember CLI is developed and maintained by a group of open source contributors
 
 ### Places to contribute
 
-- [The main Ember CLI codebase](https://github.com/ember-cli/ember-cli) 
+- [The main Ember CLI codebase](https://github.com/ember-cli/ember-cli)
 - [This documentation site](https://github.com/ember-learn/cli-guides)
-- Official projects under the [Ember CLI organization](https://github.com/ember-cli/) 
+- Official projects under the [Ember CLI organization](https://github.com/ember-cli/)
 - Search the community's CLI plugins on [Ember Observer](https://emberobserver.com)

--- a/guides/index.md
+++ b/guides/index.md
@@ -23,7 +23,7 @@ There are thousands of JavaScript libraries that work great in Ember. When an [n
 To view some of the most popular addons, visit [Ember Observer](https://emberobserver.com).
 
 Although Ember-specific packages are more specific, you can use your favorite npm packages directly too.
-By default, Ember apps created through Ember CLI include the `ember-auto-import` dependency, which enables importing npm packages directly. For example, if you want to use the Highcharts library in your application,
+By default, Ember apps created through Ember CLI include the `ember-auto-import` dependency, which enables importing npm packages directly. For example, if you want to use the `highcharts` library in your application,
 you can install and import it in your application without any other configuration. Be sure to visit the [ember-auto-import](https://github.com/ef4/ember-auto-import) documentation for more advanced usage!
 
 ## Why do we need a CLI?


### PR DESCRIPTION
Now that Ember Auto Import is a default, we can say that 'it just works'

(I used Highcharts as the example because I've used it before and I know it works, but can be changed to any other example, or can remove the example too)