### PR TITLE
Add info about yarn by default

### DIFF
--- a/guides/basic-use/assets-and-dependencies.md
+++ b/guides/basic-use/assets-and-dependencies.md
@@ -57,6 +57,14 @@ is incompatible with some CI systems.
 To switch from `yarn` to `npm`, delete the `yarn.lock`
 and run `npm install` to generate a `package-lock.json`.
 
+To have Ember CLI use `yarn` by default for all new projects, create a `.ember-cli` file in your home directory with:
+
+```json
+{
+  "yarn": true
+}
+```
+
 Further documentation about npm and Yarn is available at their official
 documentation pages:
 

--- a/guides/basic-use/cli-commands.md
+++ b/guides/basic-use/cli-commands.md
@@ -61,6 +61,7 @@ ember new camping-trip-tracker --yarn
 ### Learn more
 
 - [Ember Quickstart Guide](https://guides.emberjs.com/release/getting-started/quick-start/) for creating a first app
+- [npm and Yarn](../assets-and-dependencies/#npmandyarn) for more on using package managers with Ember CLI
 
 ## Serve the app locally
 


### PR DESCRIPTION
Setting `"yarn": true` in `.ember-cli` is undocumented. This adds some documentation about it.