### PR TITLE
Updated Introduction by simplifying the writing

### DIFF
--- a/guides/index.md
+++ b/guides/index.md
@@ -1,5 +1,5 @@
 The Ember CLI (command line interface) is the official way to create, build, test, and serve the files that make up an Ember app or addon.
-Many things have to happen before a web app is ready for the browser. The Ember CLI helps you get there with zero configuration.
+Many things have to happen before a web app is ready for the browser. Ember CLI helps you get there with zero configuration.
 
 ```shell
 npm install -g ember-cli

--- a/guides/index.md
+++ b/guides/index.md
@@ -34,7 +34,7 @@ you can install and import it without any other configuration. Be sure to visit 
 
 ## Why do we need a CLI?
 
-The Ember CLI's job is to make your work easier.
+Ember CLI's job is to make your work easier.
 
 The CLI is like a dependency packager, test runner, optimizer, and local server—all rolled into one. Since all features were built to work together, common tasks (e.g. upgrading the app version and deploying the app) can be automated with production-ready, open source plugins. The CLI is backwards-compatible with older Ember apps and maintains a 6-week release schedule.
 

--- a/guides/index.md
+++ b/guides/index.md
@@ -1,5 +1,5 @@
-The Ember CLI (command line interface) is the official way to create, build, test, and serve the files that make up an Ember.js app or addon.
-Many things have to happen before any web app is ready for the browser, and the Ember CLI helps you get there with zero configuration.
+The Ember CLI (command line interface) is the official way to create, build, test, and serve the files that make up an Ember app or addon.
+Many things have to happen before a web app is ready for the browser. The Ember CLI helps you get there with zero configuration.
 
 ```shell
 npm install -g ember-cli
@@ -11,37 +11,43 @@ for information on the latest releases and new features.
 
 ## Learning the CLI
 
-Although these CLI guides have a lot of content, a typical Ember developer will only need to know and use a small fraction of the information.
-For new users, the recommended learning path is to first do the Ember.js [Quickstart](https://guides.emberjs.com/release/getting-started/quick-start/) and [Tutorial](https://guides.emberjs.com/release/tutorial/), which teach the commands while building a sample app. Then, review the Basic Use section of this site as a reference resource.
+You will find a lot of information in the Ember CLI Guides. Rest assured, you will only need to know and use a small fraction in a typical day.
 
-The CLI comes with a command-line-based help system too. At any point, if you're curious what a command does and what the options are, you can add `--help` to the command and press enter to find out more.
+For new users, the recommended learning path is to first do the Ember.js [Quickstart](https://guides.emberjs.com/release/getting-started/quick-start/) and [Tutorial](https://guides.emberjs.com/release/tutorial/). These teach the commands while building a sample app. Then, review the [Basic use](./basic-use) section of this site as a reference.
+
+The CLI comes with a help system too. At any point, if you're not sure what a command does and what its options are, you can add `--help` to the command and press enter to find out more.
+
+```shell
+ember generate component --help
+```
 
 ## What are addons?
 
-There are thousands of JavaScript libraries that work great in Ember. When an [npm package](https://www.npmjs.com/) offers some Ember-specific conveniences, we call it an “addon.” Ember CLI’s addon system provides a way to create reusable units of code, share components and styling, extend the build tooling, and more — all with minimal configuration.
+There are thousands of JavaScript libraries that work great in Ember.
 
-To view some of the most popular addons, visit [Ember Observer](https://emberobserver.com).
+When an [npm package](https://www.npmjs.com/) offers some Ember-specific features, we call it an "addon." An addon provides a way to write reusable code, share components and styling, extend the build tooling, and more—all with minimal configuration. You can visit [Ember Observer](https://emberobserver.com) to search addons.
 
-Although Ember-specific packages are more specific, you can use your favorite npm packages directly too.
-By default, Ember apps created through Ember CLI include the `ember-auto-import` dependency, which enables importing npm packages directly. For example, if you want to use the `highcharts` library in your application,
-you can install and import it in your application without any other configuration. Be sure to visit the [ember-auto-import](https://github.com/ef4/ember-auto-import) documentation for more advanced usage!
+You can also use npm packages that were made for the wider JavaScript community.
+
+Since `v3.x`, Ember apps include the `ember-auto-import` dependency, which enables importing npm packages directly. For example, if you want to use `highcharts` in your application,
+you can install and import it without any other configuration. Be sure to visit the [ember-auto-import](https://github.com/ef4/ember-auto-import) documentation for more advanced usage!
 
 ## Why do we need a CLI?
 
-The Ember CLI is like a dependency packager, test runner, optimizer, and local server all rolled into one. Since all the features were built to work together, common tasks (such as upgrading the app version or deploying) can be automated with production-ready, open source plugins. The CLI is backwards-compatible with older Ember apps and maintains a six-week release schedule.
+The Ember CLI's job is to make your work easier.
 
-The CLI's job is to make your work easier.
-It was built with the philosophy that a developer should be able to focus on building great apps, not re-engineering how to fit all the pieces together at each stage of an app's lifecycle. The result is that apps are more maintainable and approachable, since there are established architectural patterns across individuals, teams, and companies.
+The CLI is like a dependency packager, test runner, optimizer, and local server—all rolled into one. Since all features were built to work together, common tasks (e.g. upgrading the app version and deploying the app) can be automated with production-ready, open source plugins. The CLI is backwards-compatible with older Ember apps and maintains a 6-week release schedule.
 
-However, if you want to make your own adjustments like using a different testing library, you still can.
+The CLI was also built with the idea that a developer should be able to focus on building great apps, not re-engineering how to fit pieces together throughout an app's lifecycle. Apps become maintainable and approachable, since there are established architectural patterns across individuals, teams, and companies.
+However, if you want to make your own adjustments, such as using a different testing library, you still can.
 
 ## Getting help
 
-Do you have questions? Run into an issue or a bug? Get support from the community. A list of chat rooms, forums, and more are available [here](https://www.emberjs.com/community/).
+Did you have questions? Run into an issue or a bug? Get support from the community. A list of chat rooms, forums, and more is available on the [Community](https://www.emberjs.com/community/) page.
 
 ## Contributing
 
-The Ember CLI is developed and maintained by a group of open source contributors from many different companies and backgrounds. If you have an idea for a feature, a bug to report, or just want to help out where it is needed, you can reach the team via [GitHub](https://github.com/ember-cli), the [Ember Community forums and chat](https://www.emberjs.com/community/), or drop by the weekly meeting that is open to the public.
+The Ember CLI is developed and maintained by a group of open source contributors from various companies and backgrounds. If you want to propose an idea for a feature, report a bug, or learn more how you can help, you can reach the team on [GitHub](https://github.com/ember-cli) and [Discord](https://discord.com/invite/emberjs). You can also drop by the weekly meeting that is open to the public.
 
 ### Places to contribute
 


### PR DESCRIPTION
## Description

I was reviewing what we mention in the CLI Guides with regards to the folder structure for an in-repo addon. On the long horizon, I'd like to document the colocated folder structure in Octane (this pertains to the issue https://github.com/ember-learn/cli-guides/issues/135).

As I review each section, if it's okay with the team, I'd like to update the section by simplifying the writing (the grammar). For example, in this PR, I preferred 2 short sentences instead of 1 joined by an "and" or a "which." I'm hoping that the result is a writing that is easier to parse and feels conversational when read out aloud.