### PR TITLE
Ember addons: link to commands reference

### DIFF
--- a/guides/writing-addons/index.md
+++ b/guides/writing-addons/index.md
@@ -16,6 +16,8 @@ ember addon <addon-name> [options]
 
 A directory called `<addon-name>` will be created containing a structure similar to an Ember app. You won't need to use all the files to make a useful addon. By convention, _most_ Ember addons start with `ember` in the name, like `ember-basic-dropdown`. This will help other developers find your addon.
 
+For more options behind this command, refer to the [CLI commands reference](https://cli.emberjs.com/release/advanced-use/cli-commands-reference/) section.
+
 ### Addon file structure
 
 In some ways, an addon is like a mini Ember app. It has a very similar file structure, uses a lot of the same API methods, and can do most things that apps can do.

--- a/guides/writing-addons/index.md
+++ b/guides/writing-addons/index.md
@@ -16,7 +16,7 @@ ember addon <addon-name> [options]
 
 A directory called `<addon-name>` will be created containing a structure similar to an Ember app. You won't need to use all the files to make a useful addon. By convention, _most_ Ember addons start with `ember` in the name, like `ember-basic-dropdown`. This will help other developers find your addon.
 
-For more options behind this command, refer to the [CLI commands reference](https://cli.emberjs.com/release/advanced-use/cli-commands-reference/) section.
+To see all options for `ember addon`, refer to the [CLI commands reference](../advanced-use/cli-commands-reference/) section.
 
 ### Addon file structure
 


### PR DESCRIPTION
`ember addon` is not a common command. This commit links to the command's available options for easier navigation.