### PR TITLE
add ember generate blueprints to cli reference

### DIFF
--- a/.local.dic
+++ b/.local.dic
@@ -1,5 +1,6 @@
 .scss
 .vimrc
+api
 Autocomplete
 Autoprefixer
 autosave
@@ -24,6 +25,7 @@ ember-cli-github-pages
 ember-concurrency
 ember-d3
 ember-bootstrap
+ember-cli
 ember-cli-build
 ember-cli-deploy
 ember-cli-less
@@ -31,6 +33,7 @@ ember-cli-mirage
 ember-cli-sass
 ember-cli-sri
 ember-cli-typescript
+ember-data
 ember-intl
 ember-lifeline
 ember-mode
@@ -93,6 +96,7 @@ torii
 transpilation
 UAC
 URL-safe
+util
 VirtualBox
 VM
 VMware

--- a/guides/advanced-use/cli-commands-reference.md
+++ b/guides/advanced-use/cli-commands-reference.md
@@ -174,6 +174,439 @@ ember generate <blueprint> <options...>
     relative to the root of the project.
 ```
 
+### Available blueprints from `ember-source`
+
+#### `ember generate acceptance-test`
+
+Generates an acceptance test for a feature.
+
+```bash
+ember generate acceptance-test <name>
+  Generates an acceptance test for a feature.
+```
+
+#### `ember generate component`
+
+Generates a component.
+
+```bash
+ember generate component <name> <options...>
+  Generates a component.
+  --path (String) (Default: components)
+    aliases: --no-path (--path="")
+  --component-class (@ember/component, @glimmer/component, @ember/component/template-only, "") (Default: --no-component-class)
+    aliases: -cc (--component-class=@ember/component), -gc (--component-class=@glimmer/component), -tc (--component-class=@ember/component/template-only), -nc (--component-class=""), --no-component-class (--component-class=""), --with-component-class (--component-class=@glimmer/component)
+  --component-structure (flat, nested, classic) (Default: flat)
+    aliases: -fs (--component-structure=flat), -ns (--component-structure=nested), -cs (--component-structure=classic)
+```
+
+#### `ember generate component-addon`
+
+Generates a component.
+
+```bash
+ember generate component-addon <name>
+  Generates a component.
+```
+
+#### `ember generate component-class`
+
+Generates a component class.
+
+```bash
+ember generate component-class <name> <options...>
+  Generates a component class.
+  --path (String) (Default: components)
+    aliases: --no-path (--path="")
+  --component-class (@ember/component, @glimmer/component, @ember/component/template-only) (Default: @glimmer/component)
+    aliases: -cc (--component-class=@ember/component), -gc (--component-class=@glimmer/component), -tc (--component-class=@ember/component/template-only)
+  --component-structure (flat, nested, classic) (Default: flat)
+    aliases: -fs (--component-structure=flat), -ns (--component-structure=nested), -cs (--component-structure=classic)
+```
+
+#### `ember generate component-class-addon`
+
+Generates a component class.
+
+```bash
+ember generate component-class-addon <name>
+  Generates a component class.
+```
+
+#### `ember generate component-test`
+
+Generates a component integration or unit test.
+
+```bash
+ember generate component-test <name> <options...>
+  Generates a component integration or unit test.
+  --test-type (integration, unit) (Default: integration)
+    aliases: -i (--test-type=integration), -u (--test-type=unit), --integration (--test-type=integration), -unit (--test-type=unit)
+```
+
+#### `ember generate controller`
+
+Generates a controller.
+
+```bash
+ember generate controller <name>
+  Generates a controller.
+```
+
+#### `ember generate controller-test`
+
+Generates a controller unit test.
+
+```bash
+ember generate controller-test <name>
+  Generates a controller unit test.
+```
+
+#### `ember generate helper`
+
+Generates a helper function.
+
+```bash
+ember generate helper <name>
+  Generates a helper function.
+```
+
+#### `ember generate helper-addon`
+
+Generates an import wrapper.
+
+```bash
+ember generate helper-addon <name>
+  Generates an import wrapper.
+```
+
+#### `ember generate helper-test`
+
+Generates a helper integration test or a unit test.
+
+```bash
+ember generate helper-test <name> <options...>
+  Generates a helper integration test or a unit test.
+  --test-type (integration, unit) (Default: integration)
+    aliases: -i (--test-type=integration), -u (--test-type=unit), --integration (--test-type=integration), -unit (--test-type=unit)
+```
+
+#### `ember generate initializer`
+
+Generates an initializer.
+
+```bash
+ember generate initializer <name>
+  Generates an initializer.
+```
+
+#### `ember generate initializer-addon`
+
+Generates an import wrapper.
+
+```bash
+ember generate initializer-addon <name>
+  Generates an import wrapper.
+```
+
+#### `ember generate initializer-test`
+
+Generates an initializer unit test.
+
+```bash
+ember generate initializer-test <name>
+  Generates an initializer unit test.
+```
+
+#### `ember generate instance-initializer`
+
+Generates an instance initializer.
+
+```bash
+ember generate instance-initializer <name>
+  Generates an instance initializer.
+```
+
+#### `ember generate instance-initializer-addon`
+
+Generates an import wrapper.
+
+```bash
+ember generate instance-initializer-addon <name>
+  Generates an import wrapper.
+```
+
+#### `ember generate instance-initializer-test`
+
+Generates an instance initializer unit test.
+
+```bash
+ember generate instance-initializer-test <name>
+  Generates an instance initializer unit test.
+```
+
+#### `ember generate mixin`
+
+Generates a mixin.
+
+```bash
+ember generate mixin <name>
+  Generates a mixin.
+```
+
+#### `ember generate mixin-test`
+
+Generates a mixin unit test.
+
+```bash
+ember generate mixin-test <name>
+  Generates a mixin unit test.
+```
+
+#### `ember generate route`
+
+Generates a route and a template, and registers the route with the router.
+
+```bash
+ember generate route <name> <options...>
+  Generates a route and a template, and registers the route with the router.
+  --path (String) (Default: "")
+  --skip-router (Boolean) (Default: false)
+  --reset-namespace (Boolean)
+```
+
+#### `ember generate route-addon`
+
+Generates import wrappers for a route and its template.
+
+```bash
+ember generate route-addon <name>
+  Generates import wrappers for a route and its template.
+```
+
+#### `ember generate route-test`
+
+Generates a route unit test.
+
+```bash
+ember generate route-test <name> <options...>
+  Generates a route unit test.
+  --reset-namespace (Boolean)
+```
+
+#### `ember generate service`
+
+Generates a service.
+
+```bash
+ember generate service <name>
+  Generates a service.
+```
+
+#### `ember generate service-test`
+
+Generates a service unit test.
+
+```bash
+ember generate service-test <name>
+  Generates a service unit test.
+```
+
+#### `ember generate template`
+
+Generates a template.
+
+```bash
+ember generate template <name>
+  Generates a template.
+```
+
+#### `ember generate util`
+
+Generates a simple utility module/function.
+
+```bash
+ember generate util <name>
+  Generates a simple utility module/function.
+```
+
+#### `ember generate util-test`
+
+Generates a `util` unit test.
+
+```bash
+ember generate util-test <name>
+  Generates a util unit test.
+```
+
+### Available blueprints from `ember-data`
+
+#### `ember generate adapter`
+
+Generates an `ember-data` adapter.
+
+```bash
+ember generate adapter <name> <options...>
+  Generates an ember-data adapter.
+  --base-class (String)
+```
+
+#### `ember generate adapter`
+
+Generates an `ember-data` adapter unit test
+
+```bash
+ember generate adapter-test <name>
+  Generates an ember-data adapter unit test
+```
+
+#### `ember generate model`
+
+Generates an `ember-data` model.
+
+```bash
+ember generate model <name> <attr:type>
+  Generates an ember-data model.
+```
+
+#### `ember generate model`
+
+Generates a model unit test.
+
+```bash
+ember generate model-test <name>
+  Generates a model unit test.
+```
+
+#### `ember generate serializer`
+
+Generates an `ember-data` serializer.
+
+```bash
+ember generate serializer <name> <options...>
+  Generates an ember-data serializer.
+  --base-class (String)
+```
+
+#### `ember generate serializer`
+
+Generates a serializer unit test.
+
+```bash
+ember generate serializer-test <name>
+  Generates a serializer unit test.
+```
+
+#### `ember generate transform`
+
+Generates an `ember-data` value transform.
+
+```bash
+ember generate transform <name>
+  Generates an ember-data value transform.
+```
+
+#### `ember generate transform`
+
+Generates a transform unit test.
+
+```bash
+ember generate transform-test <name>
+  Generates a transform unit test.
+```
+
+### Available blueprints from `ember-cli`
+
+#### `ember generate addon`
+
+The default blueprint for `ember-cli` addons.
+
+```bash
+ember generate addon <name>
+  The default blueprint for ember-cli addons.
+```
+
+#### `ember generate addon-import`
+
+Generates an import wrapper.
+
+```bash
+ember generate addon-import <name>
+  Generates an import wrapper.
+```
+
+#### `ember generate app`
+
+The default blueprint for `ember-cli` projects.
+
+```bash
+ember generate app <name>
+  The default blueprint for ember-cli projects.
+```
+
+#### `ember generate blueprint`
+
+Generates a blueprint and definition.
+
+```bash
+ember generate blueprint <name>
+  Generates a blueprint and definition.
+```
+
+#### `ember generate http-mock`
+
+Generates a `mock api` endpoint in `/api` prefix.
+
+```bash
+ember generate http-mock <endpoint-path>
+  Generates a mock api endpoint in /api prefix.
+```
+
+#### `ember generate http-proxy`
+
+Generates a relative proxy to another server.
+
+```bash
+ember generate http-proxy <local-path> <remote-url>
+  Generates a relative proxy to another server.
+```
+
+#### `ember generate in-repo-addon`
+
+The blueprint for addon in repo `ember-cli` addons.
+
+```bash
+ember generate in-repo-addon <name>
+  The blueprint for addon in repo ember-cli addons.
+```
+
+#### `ember generate lib`
+
+Generates a lib directory for in-repo addons.
+
+```bash
+ember generate lib <name>
+  Generates a lib directory for in-repo addons.
+```
+
+#### `ember generate server`
+
+Generates a server directory for mocks and proxies.
+
+```bash
+ember generate server <name>
+  Generates a server directory for mocks and proxies.
+```
+
+#### `ember generate vendor-shim`
+
+Generates an ES6 module shim for global libraries.
+
+```bash
+ember generate vendor-shim <name>
+  Generates an ES6 module shim for global libraries.
+```
+
 ### `ember help`
 
 Outputs the usage instructions for all commands

--- a/guides/advanced-use/cli-commands-reference.md
+++ b/guides/advanced-use/cli-commands-reference.md
@@ -437,7 +437,7 @@ ember generate util <name>
 
 #### `ember generate util-test`
 
-Generates a `util` unit test.
+Generates a util unit test.
 
 ```bash
 ember generate util-test <name>
@@ -448,7 +448,7 @@ ember generate util-test <name>
 
 #### `ember generate adapter`
 
-Generates an `ember-data` adapter.
+Generates an ember-data adapter.
 
 ```bash
 ember generate adapter <name> <options...>
@@ -458,7 +458,7 @@ ember generate adapter <name> <options...>
 
 #### `ember generate adapter-test`
 
-Generates an `ember-data` adapter unit test
+Generates an ember-data adapter unit test
 
 ```bash
 ember generate adapter-test <name>
@@ -467,7 +467,7 @@ ember generate adapter-test <name>
 
 #### `ember generate model`
 
-Generates an `ember-data` model.
+Generates an ember-data model.
 
 ```bash
 ember generate model <name> <attr:type>
@@ -485,7 +485,7 @@ ember generate model-test <name>
 
 #### `ember generate serializer`
 
-Generates an `ember-data` serializer.
+Generates an ember-data serializer.
 
 ```bash
 ember generate serializer <name> <options...>
@@ -504,7 +504,7 @@ ember generate serializer-test <name>
 
 #### `ember generate transform`
 
-Generates an `ember-data` value transform.
+Generates an ember-data value transform.
 
 ```bash
 ember generate transform <name>
@@ -524,7 +524,7 @@ ember generate transform-test <name>
 
 #### `ember generate addon`
 
-The default blueprint for `ember-cli` addons.
+The default blueprint for ember-cli addons.
 
 ```bash
 ember generate addon <name>
@@ -542,7 +542,7 @@ ember generate addon-import <name>
 
 #### `ember generate app`
 
-The default blueprint for `ember-cli` projects.
+The default blueprint for ember-cli projects.
 
 ```bash
 ember generate app <name>
@@ -560,7 +560,7 @@ ember generate blueprint <name>
 
 #### `ember generate http-mock`
 
-Generates a `mock api` endpoint in `/api` prefix.
+Generates a mock api endpoint in /api prefix.
 
 ```bash
 ember generate http-mock <endpoint-path>
@@ -578,7 +578,7 @@ ember generate http-proxy <local-path> <remote-url>
 
 #### `ember generate in-repo-addon`
 
-The blueprint for addon in repo `ember-cli` addons.
+The blueprint for addon in repo ember-cli addons.
 
 ```bash
 ember generate in-repo-addon <name>
@@ -628,7 +628,7 @@ ember help <command-name (Default: all)> <options...>
 
 ### `ember init`
 
-Creates a new `ember-cli` project in the current folder.
+Creates a new ember-cli project in the current folder.
 
 ```bash
 ember init <glob-pattern> <options...>
@@ -654,7 +654,7 @@ ember init <glob-pattern> <options...>
 
 ### `ember install`
 
-Installs an `ember-cli` addon from npm.
+Installs an ember-cli addon from npm.
 
 ```bash
 ember install <addon-name> <options...>
@@ -809,7 +809,7 @@ ember test <options...>
 
 ### `ember version`
 
-outputs `ember-cli` version
+outputs ember-cli version
 
 ```bash
 ember version <options...>

--- a/guides/advanced-use/cli-commands-reference.md
+++ b/guides/advanced-use/cli-commands-reference.md
@@ -41,6 +41,10 @@ Available commands from Ember CLI in alphabetical order:
       <td>Generates new code from blueprints.</td>
     </tr>
     <tr>
+      <td><a href="#emberhelp"><code>ember help</code></a></td>
+      <td>Outputs the usage instructions for all commands.</td>
+    </tr>
+    <tr>
       <td><a href="#emberinit"><code>ember init</code></a></td>
       <td>Creates a new ember-cli project in the current folder.</td>
     </tr>

--- a/guides/advanced-use/cli-commands-reference.md
+++ b/guides/advanced-use/cli-commands-reference.md
@@ -451,7 +451,7 @@ ember generate adapter <name> <options...>
   --base-class (String)
 ```
 
-#### `ember generate adapter`
+#### `ember generate adapter-test`
 
 Generates an `ember-data` adapter unit test
 
@@ -469,7 +469,7 @@ ember generate model <name> <attr:type>
   Generates an ember-data model.
 ```
 
-#### `ember generate model`
+#### `ember generate model-test`
 
 Generates a model unit test.
 
@@ -488,7 +488,7 @@ ember generate serializer <name> <options...>
   --base-class (String)
 ```
 
-#### `ember generate serializer`
+#### `ember generate serializer-test`
 
 Generates a serializer unit test.
 
@@ -506,7 +506,7 @@ ember generate transform <name>
   Generates an ember-data value transform.
 ```
 
-#### `ember generate transform`
+#### `ember generate transform-test`
 
 Generates a transform unit test.
 

--- a/guides/advanced-use/cli-commands-reference.md
+++ b/guides/advanced-use/cli-commands-reference.md
@@ -427,6 +427,7 @@ ember generate template <name>
 
 #### `ember generate util`
 
+<!--alex ignore simple-->
 Generates a simple utility module/function.
 
 ```bash


### PR DESCRIPTION
This PR attempts to add additional CLI information for each `ember generate` blueprint provided by default. The blueprints are the following:

- ember-source
  - acceptance-test
  - component
  - component-addon
  - component-class
  - component-class-addon
  - component-test
  - controller
  - controller-test
  - helper
  - helper-test
  - initializer
  - initializer-addon
  - initializer-test
  - instance-initializer
  - instance-initializer-addon
  - instance-initializer-test
  - mixin
  - mixin-test
  - route
  - route-addon
  - route-test
  - service
  - service-test
  - template
  - util
  - util-test

- ember-data
  - adapter
  - adapter-test
  - model
  - model-test
  - serializer
  - serializer-test
  - transform
  - transform-test

- ember-cli
  - addon
  - addon-import
  - app
  - blueprint
  - http-mock
  - http-proxy
  - in-repo-addon
  - lib
  - server
  - vendor-shim

Related to #162

---

## Screenshot

![image](https://user-images.githubusercontent.com/127994/97810315-f7742200-1c40-11eb-863a-0e103df03224.png)
