### PR TITLE
Generate a JSONAPISerializer to stop relying on the defaultSerializer behavior

### DIFF
--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,0 +1,3 @@
+import JSONAPISerializer from '@ember-data/serializer/json-api';
+
+export default class ApplicationSerializer extends JSONAPISerializer {}

--- a/tests/unit/serializers/application-test.js
+++ b/tests/unit/serializers/application-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Serializer | application', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let serializer = store.serializerFor('application');
+
+    assert.ok(serializer);
+  });
+
+  test('it serializes records', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let record = store.createRecord('application', {});
+
+    let serializedRecord = record.serialize();
+
+    assert.ok(serializedRecord);
+  });
+});


### PR DESCRIPTION
Deprecation information: https://deprecations.emberjs.com/ember-data/v3.x/#toc_ember-data-default-serializers