### PR TITLE
Updated info on the index page of the writing addons section

### DIFF
--- a/guides/writing-addons/index.md
+++ b/guides/writing-addons/index.md
@@ -37,6 +37,7 @@ Fortunately, when you run `ember generate component my-component-name` in an add
 
 #### `public/`
 
+This directory is not created by default in a new addon, but you can add it manually if there are static assets (like images) that you want to include in your addon.
 You can add static assets in the `public/` directory in your addon, and they will automatically be
 merged into the public directory in the host app under a folder with the name of your addon.
 


### PR DESCRIPTION
If merged, this PR updates the text about the `public/` folder of an addon. 

Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR. 