### PR TITLE
Remove individually-listed required packages that are (now) dependencies of others in the list

### DIFF
--- a/guides/writing-addons/in-repo-addons.md
+++ b/guides/writing-addons/in-repo-addons.md
@@ -32,10 +32,8 @@ appropriate file extension for your addon stylesheet file.
 In order to compile HTMLBars templates that are part of your in-repo-addon,
 your `package.json` file will need to include following dependencies:
 
-- `babel-plugin-htmlbars-inline-precompile`
 - `ember-cli-babel`
 - `ember-cli-htmlbars`
-- `ember-cli-htmlbars-inline-precompile`
 
 (Use the same versions found in your Ember CLI Application's `package.json`)
 


### PR DESCRIPTION
The https://cli.emberjs.com/release/writing-addons/in-repo-addons/#usingtemplateswithaninrepoaddon documentation lists `babel-plugin-htmlbars-inline-precompile` and `ember-cli-htmlbars-inline-precompile` as required dependencies, but they are no longer individually required.

`babel-plugin-htmlbars-inline-precompile` is a(n included) dependency of `ember-cli-htmlbars` (https://github.com/ember-cli/ember-cli-htmlbars/blob/master/package.json#L37)

`ember-cli-htmlbars-inline-precompile` is also a(n included) dependency of `ember-cli-htmlbars` (https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile)

