### PR TITLE
Remove the `--test-type` option from the helper-test blueprint

### DIFF
--- a/guides/advanced-use/blueprints.md
+++ b/guides/advanced-use/blueprints.md
@@ -65,7 +65,7 @@ The accompanying test is in another blueprint. It has the same name with a `-tes
   blueprints/helper-test
   ├── files
   │   └── tests
-  │       └── unit
+  │       └── integration
   │           └── helpers
   │               └── __name__-test.js
   └── index.js

--- a/guides/advanced-use/cli-commands-reference.md
+++ b/guides/advanced-use/cli-commands-reference.md
@@ -286,13 +286,11 @@ ember generate helper-addon <name>
 
 #### `ember generate helper-test`
 
-Generates a helper integration test or a unit test.
+Generates a helper integration test.
 
 ```bash
-ember generate helper-test <name> <options...>
-  Generates a helper integration test or a unit test.
-  --test-type (integration, unit) (Default: integration)
-    aliases: -i (--test-type=integration), -u (--test-type=unit), --integration (--test-type=integration), -unit (--test-type=unit)
+ember generate helper-test <name>
+  Generates a helper integration test.
 ```
 
 #### `ember generate initializer`


### PR DESCRIPTION
The [`--test-type` option is being removed in ember-source](https://github.com/emberjs/ember.js/pull/19808), so this PR updates the guides to match that change.