### PR TITLE
Remove references to Bower

### DIFF
--- a/guides/advanced-use/debugging.md
+++ b/guides/advanced-use/debugging.md
@@ -88,9 +88,6 @@ Some common steps are to stop the server, try one or more of these steps, and st
 - Run `npm install` or `yarn install`
 - Delete the `node_modules` directory and run `npm install` or `yarn install`
 - Delete the `dist` directory (found in apps with versions < 3.4), delete `node_modules`, and `npm install` or `yarn install`
-- If an app uses Bower (a deprecated, npm-like tool), follow all the steps above
-
-in addition to deleting `bower_components` and running `bower install`.
 
 [1]: https://nodejs.org/api/debugger.html
 [2]: https://docs.npmjs.com/cli/link

--- a/guides/appendix/dev-tools.md
+++ b/guides/appendix/dev-tools.md
@@ -109,8 +109,6 @@ Mark as `Excluded`:
 Mark as `Resource Root`:
 ```shell
 /
-/bower_components
-/bower_components/ember-qunit/lib
 /public
 ```
 

--- a/guides/basic-use/assets-and-dependencies.md
+++ b/guides/basic-use/assets-and-dependencies.md
@@ -16,9 +16,6 @@ The code itself goes in `node_modules` during `npm install`, just like in many n
 - The `styles` directory, for stylesheets like CSS, SASS, or LESS
 plus folders like `vendor` and `public` that can hold many other files of the developer's choice
 
-Some older apps may use a package manager and registry called Bower, which has
-a `bower_components` directory. Bower itself is deprecated and should not be used.
-
 <!--
 If addons are installed accidentally with `npm install` or `yarn install`,
 the blueprints can be run with .... what?

--- a/guides/writing-addons/addon-blueprints.md
+++ b/guides/writing-addons/addon-blueprints.md
@@ -16,7 +16,6 @@ module.exports = {
 In addition to the standard blueprint hooks, the default blueprint can use these hooks.
 
 * `addAddonToProject`
-* `addBowerPackageToProject`
 * `addPackageToProject`
 
 #### addAddonToProject
@@ -26,12 +25,6 @@ Installs another Ember addon in the client application
 #### addPackageToProject
 
 Installs an npm package or dependency into the client application
-
-#### addBowerPackageToProject
-
-Installs a Bower package or dependency into the client application.
-Bower is a package manager that is [no longer recommended for new projects](https://bower.io/),
-but you may find this hook used in older addons.
 
 Each of the hooks returns a promise, so they can all be chained with `.then()`. The following is an example of each of these:
 


### PR DESCRIPTION
Since the [Bower RFC implementation](https://github.com/ember-cli/ember-cli/pull/9707) has been merged (I assume it will be part of the upcoming `v4.2` release), I think we can start removing references to Bower from the guides?