### PR TITLE
Remove reference to deleted deployment tutorial

### DIFF
--- a/guides/basic-use/deploying.md
+++ b/guides/basic-use/deploying.md
@@ -29,7 +29,6 @@ ember build --environment production
 
 The results of the `build` command are placed in the `dist` directory within your project.
 
-For a tutorial that shows how to build your app and upload it to a web host using `scp` and `rsync`, see the [Official Ember.js Tutorial](https://guides.emberjs.com/release/tutorial/deploying/).
 
 ### Ember CLI Deploy
 


### PR DESCRIPTION
The official ember tutorial no longer has a section on how to deploy Ember (closes #257)