### PR TITLE
Mention npm scripts, per RFC-831

### DIFF
--- a/guides/advanced-use/debugging.md
+++ b/guides/advanced-use/debugging.md
@@ -1,6 +1,6 @@
 <!-- alex disable just -->
-For most Ember applications, Ember CLI "just works". Run `ember server` in your Terminal and you get
-a LiveReload development server at `http://localhost:4200`. Run `ember build`, and you get a `dist/`
+For most Ember applications, Ember CLI "just works". Run `ember server` or `npm start` in your Terminal and you get
+a LiveReload development server at `http://localhost:4200`. Run `ember build --environment=production` or `npm run build`, and you get a `dist/`
 directory with compiled assets ready to be deployed to your production server.
 
 But things don't always go smoothly and CLI commands can fail inexplicably with error messages that
@@ -67,7 +67,7 @@ For example, if your app installs [`ember-power-select`][3], and you want to tes
 You can verify this did the intended thing by checking that `node_modules/ember-power-select` is now
 a symlink pointing to the cloned repo.
 
-Now, in your app, if you run `ember server`, it should use the linked repo and any code changes in
+Now, in your app, if you run `npm start` or `ember server`, it should use the linked repo and any code changes in
 your local clone of `ember-power-select` should get picked up by the app.
 
 ## Broccoli Debug

--- a/guides/basic-use/cli-commands.md
+++ b/guides/basic-use/cli-commands.md
@@ -80,6 +80,10 @@ To stop an Ember server, press `control-c`.
 If the local server will not start due to missing dependencies, use
 `npm install` or `yarn install` to get going again.
 
+Often, developers may run `npm start` instead of `ember serve`, since
+there may be some application-specific environment variables or flags specified
+in the `start` command of the project's `package.json`.
+
 ### Example use
 
 By default, apps are served at port `4200`, but if you need to change it for some reason, you could visit your app at `http://localhost:3200` by using this command:
@@ -198,6 +202,13 @@ module('My Component', function() {
 you can run only the first test with `ember test --filter="test one"`.
 
 See `ember test --help` for more options!
+
+### Running all tests including linters
+
+`ember test` runs only the tests in the `tests` folder, so if you want to
+run additional tests such as linters too, try `npm test` instead. It will run
+all tests specified in your project's `package.json` script for the `test`
+command.
 
 ### Learn more
 - [The Ember.js Guides about Testing](https://guides.emberjs.com/release/testing/)

--- a/guides/basic-use/deploying.md
+++ b/guides/basic-use/deploying.md
@@ -15,7 +15,7 @@ As a result, you may not need to understand or configure build steps, but it's s
 
 Behind the scenes, deploying an app has two steps: building the app for production and pushing the result to a web server for hosting.
 
-There are three main options for deploying your app: using the `ember build` command, installing `ember-cli-deploy`, or using pre-made build packs.
+There are three main options for deploying your app: using the `ember build --environment=production` command, installing `ember-cli-deploy`, or using pre-made build packs.
 
 ### `ember build` and upload
 
@@ -29,6 +29,9 @@ ember build --environment production
 
 The results of the `build` command are placed in the `dist` directory within your project.
 
+Often, developers may run `npm run build` instead, since
+there may be some application-specific environment variables or flags specified
+in the `build` command of the project's `package.json`.
 
 ### Ember CLI Deploy
 

--- a/guides/writing-addons/intro-tutorial.md
+++ b/guides/writing-addons/intro-tutorial.md
@@ -62,7 +62,7 @@ There are several options to see the addon in action. We could use `npm link` or
 2. In the Ember app's `package.json`, add a `devDependencies` entry for your addon, like `"addon-name": "*"`. The `*` means that it will include all version numbers of our addon.
 3. Run `yarn install` or `npm install` in the app. (If you are using the app for the first time, you can use `npm install --prefer-offline` or `npm install --offline` instead. These alternative commands can speed up installation, because `npm install` checks the online npm registry for your addon instead of your local storage.)
 4. Add a reference to your addon's component somewhere in an app template, like `<ComponentName @buttonLabel="Register" />`
-5. Run a local server with `ember serve` and visit [http://localhost:4200](http://localhost:4200)
+5. Run a local server with `npm start` or `ember serve`, and visit [http://localhost:4200](http://localhost:4200)
 
 We should now see our addon in action!
 


### PR DESCRIPTION
We aim to teach the use of npm/yarn scripts in addition to bare CLI commands, since in real-world applications, developers may have different configurations specified in package.json scripts than the default commands would provide.

@MehulKChaudhari please review and let me know if you have any feedback!

[RFC 831](https://github.com/emberjs/rfcs/blob/master/text/0831-standardize-use-npm-yarn.md)

Since the CLI guides aim to cover the CLI behavior, I did not fully replace things like `ember serve` with `npm start`, as we may end up doing for the regular ember guides. Instead I added a little bit of prose suggesting when to use the scripts.